### PR TITLE
#168126890 User should view a specific mentor

### DIFF
--- a/UI/html/viewAllMentors.html
+++ b/UI/html/viewAllMentors.html
@@ -191,3 +191,75 @@
     <footer>
        <p>Free Mentors, Copyright &copy; 2019</p> 
     </footer>
+
+        <!-- Mentor modals --> 
+
+        <div class="modal" id="MentorModal">
+            <div class="modal-content">
+                        <div class="modal-header">
+                            <span class="button closeModalButton">&times;</span>
+                            <h2><span><div class="innerbox">
+                                    <img src="../images/user.png" alt="">
+                                    <p> <strong>Names&title of Mentor# <span class="mentor-index"></span></strong> </p>
+                                    <p> <strong>Area of expertize</strong> </p> 
+                                    
+                                </div></span></h2>
+                        </div>
+    
+                        <div class="modal-body">
+                                <h1>Resume</h1>
+                                
+                                <hr />
+                                <br> 
+                    
+                                <p >Short Description</p>
+                                <ul>
+                                    <li></li>
+                                    <li></li>
+                                    <li></li>
+                                </ul>
+                    
+                                <p >Education</p>
+                                <ul>
+                                    <li></li>
+                                    <li></li>
+                                    <li></li>
+                                </ul>
+                    
+                                <p >Skills</p>
+                                <ul>
+                                    <li></li>
+                                    <li></li>
+                                    <li></li>
+                                </ul>
+                    
+                                <p >Experience</p>
+                                <ul>
+                                    <li></li>
+                                    <li></li>
+                                    <li></li>
+                                </ul>
+                    
+                                <p >Achivements</p>
+                                <ul>
+                                    <li></li>
+                                    <li></li>
+                                    <li></li>
+                                </ul>
+                                        
+                        </div>
+     
+    
+                        <div class="modal-footer">
+                                <button class="button" name="action"> <a href="requestMentorship.html"> Request Mentorship Session with this Mentor</a></button>
+                        </div>
+                </div>
+        </div>
+    
+        
+    
+    <script src="../js/mainUserBoard.js"></script>    
+    
+    
+    </body>
+    </html> 


### PR DESCRIPTION
#### What does this PR do?
This feature adds a modal on the top of the user dashboard page in order to view a specific mentor

#### Description of Task to be completed?
The user should be able to see the the picture, the name and  title of the Mentor in the header of the modal and the detailed Biography in the body of the modal
and should be able to see the button to use when requesting a mentorship session with this particular mentor

#### How should this be manually tested?
emmanuel-nkurunziza.github.io/freeMentors/ui/html/viewAllMentors.html

#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/168126890

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/52543344/63761156-ee5f2680-c8c0-11e9-8d94-7182fb1bbfaf.png)

