### PR TITLE
#168180932 Mentor should accept mentorship

### DIFF
--- a/UI/html/acceptedMentorship.html
+++ b/UI/html/acceptedMentorship.html
@@ -1,0 +1,164 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>FreeMentors|userBoard</title>
+    <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+
+    <header>
+        <div class="container">
+            <div class="logo">
+                <h1>Free Mentors / Mentorship Session Board </h1>
+            </div>
+             <nav>
+                 <ul>
+                     <li> <strong>Welcome to this Mentorship session board</strong> </li> <br>
+                
+                    <li> <a href="index.html" class="button">Log out</a></li>
+                 </ul>
+             </nav>
+        </div>
+    </header>
+
+    <section id="main">
+        
+        <article class="page-info">
+
+           
+
+                <p>On this page, the Learner or user will be interracting with the mentor of your choice.
+                     To do so, <strong>ask</strong> ask your mentor a question. 
+                     <br>
+            
+                    The mentor will offer a mentorship session by <strong>answering</strong> the question 
+                    a llearner (user) have asked. <br>
+
+                    if you choose to decline, it will be helpful to leave a note explaining the raison why a mentorship 
+                    session has been declined <br>
+                
+                    Then you Learner, you will be able to <strong> to comment or review</strong>  the mentorship 
+                    you have received from our mentors.
+                </p>
+
+
+               
+        </article>
+
+        <ul id="user-list">
+
+            <li>
+                    <section id="boxes">
+                        
+                        <div class="container">
+    
+                            <div class="box-label">
+                                <label for="">Learner's Question</label>
+                            </div>
+    
+                            <div class="box-textarea">
+                                <textarea placeholder="Learner's question" name="" id="" cols="" rows=""></textarea>
+                            </div>
+                            
+                            <button class="button button-size"><a href="#" >REGISTER</a></button>
+                                
+                        </div>
+    
+                    </section>
+
+            </li>
+
+
+
+            <li>
+                    <section id="boxes">
+                        <div class="container">
+    
+                            <div class="box-label">
+                                <label for="">Answer from the Mentor</label>
+                            </div>
+            
+                            <div class="box-textarea">
+                                <textarea placeholder="Answer from the Mentor" name="" id="" cols="160" rows="5"></textarea>
+                            </div>
+                                    
+                            <button class="button button-size"><a href="#" >REGISTER</a></button>
+                                        
+                        </div>
+    
+                    </section>
+    
+                </li>
+
+
+                <li>
+                    <section id="boxes">
+
+                        <div class="container">
+    
+                            <div class="box-label">
+                                <label for="">Learner's review note about this session</label>
+                            </div>
+                        
+                            <div class="box-textarea">
+                                <textarea placeholder="Comment on this session" name="" id="" cols="160" rows="5"></textarea>
+                            </div>
+                                                
+                            <button class="button button-size"><a href="#" >SEND YOUR REVIEW TO THE ADMIN</a></button>
+                                                    
+                        </div>
+    
+                    </section>
+        
+                </li>
+
+        </ul>
+        
+    </section> <br><br>
+
+    <footer>
+       <p>Free Mentors, Copyright &copy; 2019</p> 
+    </footer>
+
+    <!-- welcoming modal --> 
+
+    <div class="modal" id="sessionBoardModalElts2">
+
+        <div class="modal-content">
+
+                    <div class="modal-header">
+                        <h3>STATUS OF YOUR REQUEST</h3>
+                        <button class="button closeAcceptanceNotice"> CLOSE</button>
+                    </div>
+
+                    <div class="modal-body">
+                
+                            <p>
+                            <strong>We thank you for volunteering to assist learners on this platform.</strong>  <br>
+
+                            A notification was sent to the learner (user) who have requested this mentorship
+                            to let him/her know that you have accepted to offer this mentorship. <br>
+
+                            Upon clicking the <strong>close button</strong> you will land on the mentorship session page
+                            and be able to answer the question that the learner (user) is going to ask you.                     
+                            </p>
+                              
+                    </div>
+ 
+
+                    <div class="modal-footer">
+                        <p>Free Mentors, Copyright &copy; 2019</p> 
+                    </div>
+            </div>
+    </div>
+
+    
+
+<script src="../js/mainSessionBoard2.js"></script>    
+
+
+</body>
+</html> 


### PR DESCRIPTION
#### What does this PR do?
it allows the Mentor to access the mentorship session page after accepting to give the mentorship

#### Description of Task to be completed?
after clicking the accept button, mentor lands on the  mentorship session page , but he has to first close the welcoming modal in order to land on the mentorship session page

#### How should this be manually tested?
emmanuel-nkurunziza.github.io/freeMentors/ui/html/ acceptedMentorship.html

#### Any background context you want to provide?
NA

#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/168180932

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/52543344/63894308-9ae9f700-c9ec-11e9-8a33-b527bf071c60.png)



#### Questions:
NA