### PR TITLE
#168181340 Mentor should be able tp decline a ment…

### DIFF
--- a/UI/html/declinedMentorship.html
+++ b/UI/html/declinedMentorship.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>FreeMentors|userBoard</title>
+    <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+
+    <header>
+        <div class="container">
+            <div class="logo">
+                <h1>Free Mentors / Session Board </h1>
+            </div>
+             <nav>
+                 <ul>
+                     <li> <strong>Welcome to this session board</strong> </li> <br>
+                
+                    <li> <a href="index.html" class="button">Log out</a></li>
+                 </ul>
+             </nav>
+        </div>
+    </header>
+
+    <section id="main">
+        
+        <article class="page-info">
+
+           
+
+                <p>On this page, the Learner or user will be interracting with the mentor of your choice.
+                     To do so, <strong>ask</strong> ask your mentor a question. 
+                     <br>
+            
+                    The mentor will offer a mentorship session by <strong>answering</strong> the question 
+                    a llearner (user) have asked. <br>
+
+                    if you choose to decline, it will be helpful to leave a note explaining the raison why a mentorship 
+                    session has been declined <br>
+                
+                    Then you Learner, you will be able to <strong> to comment or review</strong>  the mentorship 
+                    you have received from our mentors.
+                </p>
+
+
+               
+        </article>
+
+        <ul id="user-list">
+
+            <li>
+                    <section id="boxes">
+                        
+                        <div class="container">
+    
+                            <div class="box-label">
+                                <label for="">Learner's Question</label>
+                            </div>
+    
+                            <div class="box-textarea">
+                                <textarea placeholder="Learner's question" name="" id="" cols="160" rows="5"></textarea>
+                            </div>
+                            
+                            <button class="button button-size"><a href="" >REGISTER</a></button>
+                                
+                        </div>
+    
+                    </section>
+
+            </li>
+
+
+
+            <li>
+                    <section id="boxes">
+                        <div class="container">
+    
+                            <div class="box-label">
+                                <label for="">Answer from the Mentor</label>
+                            </div>
+            
+                            <div class="box-textarea">
+                                <textarea placeholder="Answer from the Mentor" name="" id="" cols="160" rows="5"></textarea>
+                            </div>
+                                    
+                            <button class="button button-size"><a href="" >REGISTER</a></button>
+                                        
+                        </div>
+    
+                    </section>
+    
+                </li>
+
+
+                <li>
+                    <section id="boxes">
+
+                        <div class="container">
+    
+                            <div class="box-label">
+                                <label for="">Learner's review note about this session</label>
+                            </div>
+                        
+                            <div class="box-textarea">
+                                <textarea placeholder="Comment on this session" name="" id="" cols="160" rows="5"></textarea>
+                            </div>
+                                                
+                            <button class="button button-size"><a href="" >SEND YOUR REVIEW TO THE ADMIN</a></button>
+                                                    
+                        </div>
+    
+                    </section>
+        
+                </li>
+
+        </ul>
+        
+    </section> <br><br>
+
+    <footer>
+       <p>Free Mentors, Copyright &copy; 2019</p> 
+    </footer>
+
+    <!-- welcoming modal --> 
+
+    <div class="modal" id="sessionBoardModalElts">
+
+        <div class="modal-content">
+
+                    <div class="modal-header">
+                        <h3>STATUS OF YOUR REQUEST</h3>
+                        <span class="button"> <a href="mentorBoard.html">BACK TO MENTOR BOARD</a> </span>
+                    </div>
+
+                    <div class="modal-body">
+                
+                            <p>
+                            This request for a mentorship session has been declined...                            
+                            </p>
+
+                            <div class="box-label">
+                                    <label for="">Reason(s) to decline this Mentorship</label>
+                                </div>
+        
+                                <div class="box-textarea">
+                                    <textarea placeholder="Reason(s) to decline this Mentorship" name="" id="" cols="" rows=""></textarea>
+                                </div>
+
+                                <button class="button button-size"><a href="" >SEND TO ADMIN</a></button>
+                              
+                    </div>
+ 
+
+                    <div class="modal-footer">
+                        <p>Free Mentors, Copyright &copy; 2019</p> 
+                    </div>
+            </div>
+    </div>
+
+    
+
+<script src="../js/mainSessionBoard.js"></script>    
+
+
+</body>
+</html> 


### PR DESCRIPTION
#### What does this PR do?
it allows the user to decline to the mentorship session request

#### Description of Task to be completed?
upon click to the decline button for the learner's request, a modal with a background of the mentorship page appears and there is no possibility to land to the mentorship page. the only option is the button to return to the mentorshipboard page

#### How should this be manually tested?
emmanuel-nkurunziza.github.io/freeMentors/ui/html/ declinedMentorship.html

#### Any background context you want to provide?
NA

#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/168181340

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/52543344/63895338-22d10080-c9ef-11e9-926f-fc959dd26a54.png)

#### Questions:
NA